### PR TITLE
Improvement in function CanalInterfaceStop()

### DIFF
--- a/CDllDrvObj.h
+++ b/CDllDrvObj.h
@@ -4,6 +4,7 @@
  * Copyright (C) 2000-2008 Ake Hedman, eurosource, <akhe@eurosource.se>
  * Copyright (C) 2020 Gediminas Simanskis (gediminas@rusoku.com)
  * Copyright (C) 2020 Alexander Sorokin (sorockin@yandex.ru)
+ * Copyright (C) 2020 Uwe Vogt (uwe.vogt@uv-software.de)
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published
@@ -24,7 +25,7 @@
 
 #define DLL_MAIN_VERSION					1
 #define DLL_MINOR_VERSION					0
-#define DLL_SUB_VERSION				        2
+#define DLL_SUB_VERSION				        3
 
 // This is the vendor string - Change to your own value
 #define CANAL_DLL_VENDOR "Rusoku Technologijos UAB, Lithuania, http://www.rusoku.com"

--- a/CTouCANobj.cpp
+++ b/CTouCANobj.cpp
@@ -4,6 +4,7 @@
  * Copyright (C) 2000-2008 Ake Hedman, eurosource, <akhe@eurosource.se>
  * Copyright (C) 2020 Gediminas Simanskis (gediminas@rusoku.com)
  * Copyright (C) 2020 Alexander Sorokin (sorockin@yandex.ru)
+ * Copyright (C) 2020 Uwe Vogt (uwe.vogt@uv-software.de)
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published
@@ -1140,6 +1141,10 @@ int CTouCANObj::InterfaceStop(void)
 	if (TouCAN_stop() != TRUE)
 		return	CANAL_ERROR_COMMUNICATION;
 
-	return CANAL_ERROR_SUCCESS;
+    // signal blocking reception event
+    if (m_receiveDataEvent != NULL)
+        (void)SetEvent(m_receiveDataEvent);
+    
+    return CANAL_ERROR_SUCCESS;
 }
 


### PR DESCRIPTION
The function additionally signals the receive data event to let function WaitForSingleObjects() return. This is useful to cancel a blocking read, e.g. in a SIGINT hanler or similar. 