### PR TITLE
Minor CMake Enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
 
-project(canal)
+project(canal VERSION 1.0.5 LANGUAGES CXX C)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 11)
@@ -9,14 +9,18 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_COMPILER)
 set(CMAKE_CXX_COMPILER)
 
-#add_definitions(-DUNICODE)
-#add_definitions(-D_UNICODE)
-add_definitions(-D_MBCS)
-add_definitions(-D_WIN32_WINNT_WIN10)
+if(NOT MSVC)
+    #add_definitions(-DUNICODE)
+    #add_definitions(-D_UNICODE)
+    add_definitions(-D_MBCS)
+    add_definitions(-D_WIN32_WINNT_WIN10)
+endif()
 
-#add_compile_options(-Wall -Wextra -Wpedantic)
-add_compile_options(-Wno-pragma-once-outside-header)
-add_compile_options(-Wno-unused-parameter)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    #add_compile_options(-Wall -Wextra -Wpedantic)
+    add_compile_options(-Wno-pragma-once-outside-header)
+    add_compile_options(-Wno-unused-parameter)
+endif()
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     #add_compile_definitions(canal DEBUG_CANAL)
@@ -42,7 +46,7 @@ add_library(canal SHARED
 set_property(TARGET canal PROPERTY
         MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-target_link_libraries(canal cfgmgr32 winusb)
+target_link_libraries(canal PRIVATE cfgmgr32 winusb)
 set_target_properties(canal PROPERTIES OUTPUT_NAME "canal$<$<CONFIG:Debug>:d>")
 
 


### PR DESCRIPTION
* Added some basic compiler checks to allow building with default MSVC settings using CMake.
    - Tested to compile with both MSVC 19.36.32532.0 and Clang 15.0.1 using CMake
* Added version and languages parameters to CMake.
* Set library linkages to private, since they shouldn't be consumed directly by a consumer of this repo.

Hello. Basically this repo didn't compile for me with MSVC until I made some minor CMake changes, so I wanted to submit them to you in case you wish to include them in the base project.